### PR TITLE
Correct a programming mistake in Lecture 5

### DIFF
--- a/Lecture5.ipynb
+++ b/Lecture5.ipynb
@@ -501,7 +501,7 @@
    ],
    "source": [
     " def calcDelta(bmks, ir, lbd, trades, pert=1e-4, fpert=inst.pert_bmk) : \n",
-    "    mkt, pmkt, pkeys, cds = fpert(bmks, disc, lbd=lbd, its=3, pert=pert)\n",
+    "    mkt, pmkt, pkeys, cds = fpert(bmks, ir, lbd=lbd, its=3, pert=pert)\n",
     "    deltas, pv0 = inst.pv_deltas(mkt, pmkt, trades)\n",
     "    \n",
     "    return deltas/pert, pkeys, cds, pv0\n",


### PR DESCRIPTION
calcDelta() should use its parameter `ir` instead of the global variable `disc`.